### PR TITLE
Zone transfer

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Start test DNS server
         run: sudo ./scripts/start-test-dns.sh
 
+      - name: Start AXFR test server
+        run: ./scripts/start-test-axfr.sh
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
@@ -66,6 +69,10 @@ jobs:
       - name: Run Python tests
         run: uv run pytest blastdns/tests -vv
       
+      - name: Stop AXFR test server
+        if: always()
+        run: ./scripts/stop-test-axfr.sh || true
+
       - name: Stop test DNS server
         if: always()
         run: sudo ./scripts/stop-test-dns.sh || true

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -31,9 +31,16 @@ jobs:
       - name: Start test DNS server
         run: sudo ./scripts/start-test-dns.sh
 
+      - name: Start AXFR test server
+        run: ./scripts/start-test-axfr.sh
+
       - name: Run tests
         run: cargo test --all --locked --verbose -- --include-ignored
-      
+
+      - name: Stop AXFR test server
+        if: always()
+        run: ./scripts/stop-test-axfr.sh || true
+
       - name: Stop test DNS server
         if: always()
         run: ./scripts/stop-test-dns.sh || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "blastdns"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -673,14 +673,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -796,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -1218,16 +1219,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -1346,7 +1337,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1605,12 +1596,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1619,7 +1630,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1633,40 +1644,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1676,21 +1666,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1706,21 +1684,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1730,37 +1696,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
+ "bitflags",
  "cfg-if",
  "data-encoding",
  "enum-as-inner",
@@ -514,8 +524,10 @@ dependencies = [
  "once_cell",
  "rand",
  "ring",
+ "rustls-pki-types",
  "serde",
  "thiserror",
+ "time",
  "tinyvec",
  "tokio",
  "tracing",
@@ -831,6 +843,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,6 +913,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1130,6 +1154,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1334,25 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -1863,6 +1915,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blastdns"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 description = "Async DNS lookup library for bulk/parallel DNS resolution"
 license = "GPL-3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0.102"
 clap = { version = "4.5.60", features = ["derive"] }
 crossfire = "2.1.7"
 futures = "0.3.31"
-hickory-client = { version = "0.25.2", features = ["serde"] }
+hickory-client = { version = "0.25.2", features = ["serde", "dnssec-ring"] }
 hickory-resolver = { version = "0.25.2", default-features = false, features = ["system-config"] }
 libc = "0.2"
 lru = "0.16"

--- a/blastdns/__init__.py
+++ b/blastdns/__init__.py
@@ -1,6 +1,7 @@
 from .client import Client, ClientConfig, MockClient, get_system_resolvers
 from .models import DNSError, DNSResult, DNSResultOrError
 from .exceptions import BlastDNSError, ConfigurationError, NoResolversError, ResolverError
+from .zone_transfer import zone_transfer
 
 __all__ = [
     "ClientConfig",
@@ -14,4 +15,5 @@ __all__ = [
     "ConfigurationError",
     "NoResolversError",
     "ResolverError",
+    "zone_transfer",
 ]

--- a/blastdns/tests/test_client.py
+++ b/blastdns/tests/test_client.py
@@ -282,7 +282,7 @@ async def test_client_resolve_batch_full_skip_empty_allows_errors():
         request_timeout_ms=100,
         max_retries=0,
     )
-    bad_client = Client(["127.0.0.1:5354"], bad_config)
+    bad_client = Client(["127.0.0.1:5399"], bad_config)
 
     error_count = 0
     async for host, result in bad_client.resolve_batch_full(["example.com"], "A", skip_empty=True):
@@ -327,7 +327,7 @@ async def test_client_resolve_batch_full_skip_errors_filters_error_responses():
         request_timeout_ms=100,
         max_retries=0,
     )
-    bad_client = Client(["127.0.0.1:5354"], bad_config)
+    bad_client = Client(["127.0.0.1:5399"], bad_config)
 
     # With skip_errors=False, should get errors
     error_count = 0

--- a/blastdns/tests/test_exceptions.py
+++ b/blastdns/tests/test_exceptions.py
@@ -1,0 +1,77 @@
+import pytest
+
+from blastdns import (
+    Client,
+    MockClient,
+    BlastDNSError,
+    ConfigurationError,
+    NoResolversError,
+    ResolverError,
+)
+
+
+class TestExceptionHierarchy:
+    """Verify the exception class hierarchy."""
+
+    def test_configuration_error_is_blastdns_error(self):
+        assert issubclass(ConfigurationError, BlastDNSError)
+
+    def test_no_resolvers_error_is_configuration_error(self):
+        assert issubclass(NoResolversError, ConfigurationError)
+        assert issubclass(NoResolversError, BlastDNSError)
+
+    def test_resolver_error_is_blastdns_error(self):
+        assert issubclass(ResolverError, BlastDNSError)
+
+    def test_blastdns_error_is_exception(self):
+        assert issubclass(BlastDNSError, Exception)
+
+
+class TestConfigurationErrors:
+    """Errors raised during client construction."""
+
+    def test_invalid_resolver_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="invalid resolver"):
+            Client(["not-an-ip"])
+
+    def test_invalid_resolver_catchable_as_blastdns_error(self):
+        with pytest.raises(BlastDNSError):
+            Client(["not-an-ip"])
+
+    def test_invalid_port_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError, match="invalid resolver"):
+            Client(["8.8.8.8:99999"])
+
+
+class TestResolverErrors:
+    """Errors raised during DNS resolution."""
+
+    @pytest.mark.asyncio
+    async def test_unreachable_resolver_raises_resolver_error(self):
+        # Use a non-routable address with short timeout to trigger a resolver error
+        client = Client(
+            ["192.0.2.1"],  # TEST-NET, non-routable
+        )
+        with pytest.raises((ResolverError, BlastDNSError)):
+            await client.resolve_full("example.com", "A")
+
+
+class TestMockClientErrors:
+    """Verify mock client returns structured responses, not exceptions, for DNS-level errors."""
+
+    @pytest.mark.asyncio
+    async def test_nxdomain_is_not_exception(self):
+        """NXDOMAIN should return a DNSResult with NXDomain response code, not raise."""
+        client = MockClient()
+        client.mock_dns({"_NXDOMAIN": ["notfound.example.com"]})
+        # Should not raise - NXDOMAIN is a valid DNS response
+        result = await client.resolve_full("notfound.example.com", "A")
+        assert result.response.header.response_code == "NXDomain"
+
+    @pytest.mark.asyncio
+    async def test_unknown_host_is_not_exception(self):
+        """Hosts not in mock data should return empty results, not raise."""
+        client = MockClient()
+        client.mock_dns({})
+        result = await client.resolve("unknown.example.com", "A")
+        assert result == []

--- a/blastdns/tests/test_zone_transfer.py
+++ b/blastdns/tests/test_zone_transfer.py
@@ -1,0 +1,102 @@
+"""Integration tests for zone transfer (AXFR) support.
+
+Requires the BIND9 test server: ./scripts/start-test-axfr.sh
+The server runs on 127.0.0.1:5354 with the zonetransfer.test zone.
+"""
+
+import pytest
+
+from blastdns import zone_transfer, ConfigurationError, ResolverError, BlastDNSError
+
+AXFR_SERVER = "127.0.0.1:5354"
+AXFR_ZONE = "zonetransfer.test"
+
+
+@pytest.mark.asyncio
+async def test_zone_transfer_success():
+    """Full AXFR should return all zone records with every record type."""
+    records = await zone_transfer(AXFR_SERVER, AXFR_ZONE)
+
+    # Build lookup structures
+    record_types = {rtype for _, rtype, _ in records}
+    by_type = {}
+    for name, rtype, rdata in records:
+        by_type.setdefault(rtype, []).append((name, rdata))
+
+    # --- Verify every record type is present ---
+
+    # SOA (appears at start and end of AXFR)
+    assert "SOA" in record_types
+    soa_records = by_type["SOA"]
+    assert len(soa_records) == 2, "AXFR should have SOA at start and end"
+    assert "ns1.zonetransfer.test." in soa_records[0][1]
+
+    # NS
+    assert "NS" in record_types
+    ns_names = {rdata for _, rdata in by_type["NS"]}
+    assert "ns1.zonetransfer.test." in ns_names
+
+    # A
+    assert "A" in record_types
+    a_records = {(name, rdata) for name, rdata in by_type["A"]}
+    assert ("www.zonetransfer.test.", "127.0.0.3") in a_records
+    assert ("mail.zonetransfer.test.", "127.0.0.2") in a_records
+    assert ("ftp.zonetransfer.test.", "127.0.0.4") in a_records
+
+    # AAAA
+    assert "AAAA" in record_types
+    aaaa_records = {(name, rdata) for name, rdata in by_type["AAAA"]}
+    assert ("ipv6.zonetransfer.test.", "::1") in aaaa_records
+
+    # MX
+    assert "MX" in record_types
+    mx_data = {rdata for _, rdata in by_type["MX"]}
+    assert any("mail.zonetransfer.test." in d for d in mx_data)
+
+    # CNAME
+    assert "CNAME" in record_types
+    cname_records = {(name, rdata) for name, rdata in by_type["CNAME"]}
+    assert ("api.zonetransfer.test.", "www.zonetransfer.test.") in cname_records
+
+    # TXT
+    assert "TXT" in record_types
+    txt_data = {rdata for _, rdata in by_type["TXT"]}
+    assert any("spf1" in d for d in txt_data)
+
+    # SRV
+    assert "SRV" in record_types
+    srv_data = {rdata for _, rdata in by_type["SRV"]}
+    assert any("ldap.zonetransfer.test." in d for d in srv_data)
+
+    # PTR
+    assert "PTR" in record_types
+    ptr_records = {(name, rdata) for name, rdata in by_type["PTR"]}
+    assert ("1.0.0.zonetransfer.test.", "ns1.zonetransfer.test.") in ptr_records
+
+    # NSEC
+    assert "NSEC" in record_types
+    assert len(by_type["NSEC"]) == 2
+    nsec_data = {rdata for _, rdata in by_type["NSEC"]}
+    assert any("api.zonetransfer.test." in d for d in nsec_data)
+    assert any("ftp.zonetransfer.test." in d for d in nsec_data)
+
+
+@pytest.mark.asyncio
+async def test_zone_transfer_invalid_nameserver():
+    """Invalid nameserver should raise ConfigurationError."""
+    with pytest.raises(ConfigurationError):
+        await zone_transfer("not-an-ip", "example.com")
+
+
+@pytest.mark.asyncio
+async def test_zone_transfer_nonexistent_zone():
+    """Zone transfer for a non-existent zone should return empty results."""
+    records = await zone_transfer(AXFR_SERVER, "nonexistent.zone", timeout_secs=3.0)
+    assert len(records) == 0
+
+
+@pytest.mark.asyncio
+async def test_zone_transfer_timeout():
+    """Zone transfer against a non-routable IP should timeout."""
+    with pytest.raises((ResolverError, BlastDNSError)):
+        await zone_transfer("192.0.2.1:53", "example.com", timeout_secs=2.0)

--- a/blastdns/zone_transfer.py
+++ b/blastdns/zone_transfer.py
@@ -1,0 +1,28 @@
+"""Zone transfer (AXFR) support."""
+
+from . import _native  # type: ignore
+
+
+async def zone_transfer(nameserver, zone, timeout_secs=6.0):
+    """Perform an AXFR (full zone transfer) against a specific nameserver.
+
+    Zone transfers are TCP-based operations that download all records from a DNS zone.
+
+    Args:
+        nameserver: The nameserver to query (IP or IP:port string, e.g., "1.2.3.4" or "1.2.3.4:53")
+        zone: The zone name to transfer (e.g., "example.com")
+        timeout_secs: Connection/query timeout in seconds (default: 6.0)
+
+    Returns:
+        list[tuple[str, str, str]]: List of (name, record_type, rdata) tuples.
+
+    Raises:
+        ConfigurationError: If the nameserver address or zone name is invalid.
+        ResolverError: If the zone transfer fails (timeout, connection refused, etc.).
+
+    Example:
+        records = await zone_transfer("ns1.example.com:53", "example.com")
+        for name, rtype, rdata in records:
+            print(f"{name} {rtype} {rdata}")
+    """
+    return await _native.zone_transfer_py(nameserver, zone, timeout_secs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "blastdns"
-version = "1.7.0"
+version = "1.8.0"
 description = "Async Python interface on top of the BlastDNS resolver"
 license = "GPL-3.0"
 repository = "https://github.com/blacklanternsecurity/blastdns"

--- a/scripts/start-test-axfr.sh
+++ b/scripts/start-test-axfr.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start a BIND9 authoritative DNS server in Docker for AXFR testing.
+# Listens on 127.0.0.1:5354 (TCP+UDP).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER_NAME="blastdns-test-axfr"
+PORT="${AXFR_PORT:-5354}"
+
+# Stop any existing container
+docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+
+echo "Starting BIND9 AXFR test server on port $PORT..."
+
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "127.0.0.1:${PORT}:53/tcp" \
+    -p "127.0.0.1:${PORT}:53/udp" \
+    -v "${SCRIPT_DIR}/test-zone/named.conf:/etc/bind/named.conf:ro" \
+    -v "${SCRIPT_DIR}/test-zone/db.zonetransfer.test:/etc/bind/db.zonetransfer.test:ro" \
+    internetsystemsconsortium/bind9:9.20
+
+# Wait for it to be ready
+for i in $(seq 1 10); do
+    if docker exec "$CONTAINER_NAME" rndc status >/dev/null 2>&1; then
+        echo "BIND9 AXFR test server ready on 127.0.0.1:$PORT"
+        exit 0
+    fi
+    sleep 0.5
+done
+
+# Fallback: just check if container is running
+if docker ps --filter "name=$CONTAINER_NAME" --format '{{.Names}}' | grep -q "$CONTAINER_NAME"; then
+    sleep 1
+    echo "BIND9 AXFR test server started on 127.0.0.1:$PORT"
+else
+    echo "ERROR: BIND9 container failed to start"
+    docker logs "$CONTAINER_NAME" 2>&1 | tail -20
+    exit 1
+fi

--- a/scripts/stop-test-axfr.sh
+++ b/scripts/stop-test-axfr.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONTAINER_NAME="blastdns-test-axfr"
+
+if docker rm -f "$CONTAINER_NAME" 2>/dev/null; then
+    echo "Stopped AXFR test server"
+else
+    echo "No AXFR test server running"
+fi

--- a/scripts/test-zone/db.zonetransfer.test
+++ b/scripts/test-zone/db.zonetransfer.test
@@ -1,0 +1,41 @@
+$TTL 300
+@   IN  SOA ns1.zonetransfer.test. admin.zonetransfer.test. (
+            2024010101  ; serial
+            3600        ; refresh
+            900         ; retry
+            604800      ; expire
+            300         ; minimum TTL
+        )
+
+; NS records
+@       IN  NS      ns1.zonetransfer.test.
+
+; A records
+@       IN  A       127.0.0.1
+ns1     IN  A       127.0.0.1
+mail    IN  A       127.0.0.2
+www     IN  A       127.0.0.3
+ftp     IN  A       127.0.0.4
+ldap    IN  A       127.0.0.5
+
+; AAAA records
+ipv6    IN  AAAA    ::1
+
+; MX records
+@       IN  MX  10  mail.zonetransfer.test.
+
+; CNAME records
+api     IN  CNAME   www.zonetransfer.test.
+
+; TXT records
+@       IN  TXT     "v=spf1 include:zonetransfer.test ~all"
+
+; SRV records
+_ldap._tcp  IN  SRV     0 100 389 ldap.zonetransfer.test.
+
+; PTR records (reverse lookup)
+1.0.0   IN  PTR     ns1.zonetransfer.test.
+
+; NSEC records (for NSEC walking tests)
+@       IN  NSEC    api.zonetransfer.test. A NS SOA MX TXT AAAA NSEC
+api     IN  NSEC    ftp.zonetransfer.test. CNAME NSEC

--- a/scripts/test-zone/named.conf
+++ b/scripts/test-zone/named.conf
@@ -1,0 +1,14 @@
+options {
+    directory "/var/cache/bind";
+    listen-on port 53 { any; };
+    listen-on-v6 port 53 { any; };
+    allow-query { any; };
+    allow-transfer { any; };
+    recursion no;
+};
+
+zone "zonetransfer.test" {
+    type master;
+    file "/etc/bind/db.zonetransfer.test";
+    allow-transfer { any; };
+};

--- a/src/client.rs
+++ b/src/client.rs
@@ -482,7 +482,7 @@ mod tests {
             ..Default::default()
         };
         let bad_client = Arc::new(
-            BlastDNSClient::with_config(vec!["127.0.0.1:5354".to_string()], bad_resolver_config)
+            BlastDNSClient::with_config(vec!["127.0.0.1:5399".to_string()], bad_resolver_config)
                 .expect("client init"),
         );
 
@@ -520,7 +520,7 @@ mod tests {
             ..Default::default()
         };
         let bad_client = Arc::new(
-            BlastDNSClient::with_config(vec!["127.0.0.1:5354".to_string()], bad_resolver_config)
+            BlastDNSClient::with_config(vec!["127.0.0.1:5399".to_string()], bad_resolver_config)
                 .expect("client init"),
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod python;
 mod resolver;
 mod utils;
 mod worker;
+pub mod zone_transfer;
 
 pub use client::{BatchResult, BatchResultBasic, BlastDNSClient};
 pub use config::{
@@ -20,3 +21,4 @@ pub use error::BlastDNSError;
 pub use mock::MockBlastDNSClient;
 pub use resolver::DnsResolver;
 pub use utils::{check_ulimits, get_system_resolvers};
+pub use zone_transfer::{ZoneTransferResult, zone_transfer};

--- a/src/python.rs
+++ b/src/python.rs
@@ -626,11 +626,44 @@ fn get_system_resolvers_py() -> PyResult<Vec<String>> {
     Ok(resolver_ips.iter().map(|ip| ip.to_string()).collect())
 }
 
+/// Perform an AXFR (full zone transfer) against a specific nameserver.
+/// Returns a list of (name, record_type, rdata) tuples.
+#[pyfunction]
+#[pyo3(signature = (nameserver, zone, timeout_secs = 6.0))]
+fn zone_transfer_py<'py>(
+    py: Python<'py>,
+    nameserver: String,
+    zone: String,
+    timeout_secs: f64,
+) -> PyResult<Bound<'py, PyAny>> {
+    let timeout = std::time::Duration::from_secs_f64(timeout_secs);
+    future_into_py(py, async move {
+        let result = crate::zone_transfer::zone_transfer(&nameserver, &zone, timeout)
+            .await
+            .map_err(PyErr::from)?;
+
+        // Convert records to JSON-serializable tuples: (name, type, rdata_string)
+        let records: Vec<(String, String, String)> = result
+            .records
+            .iter()
+            .map(|record| {
+                let name = record.name().to_string();
+                let rtype = record.record_type().to_string();
+                let rdata = record.data().to_string();
+                (name, rtype, rdata)
+            })
+            .collect();
+
+        Ok(records)
+    })
+}
+
 #[pymodule]
 fn _native(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyBlastDNSClient>()?;
     m.add_class::<PyMockBlastDNSClient>()?;
     m.add_function(wrap_pyfunction!(get_system_resolvers_py, m)?)?;
+    m.add_function(wrap_pyfunction!(zone_transfer_py, m)?)?;
     // Eagerly initialize exception types so they're ready before any errors occur
     let _ = init_exception_types(py);
     Ok(())

--- a/src/zone_transfer.rs
+++ b/src/zone_transfer.rs
@@ -1,0 +1,153 @@
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::time::Duration;
+
+use futures::StreamExt;
+use hickory_client::{
+    client::{Client, ClientHandle},
+    proto::{
+        rr::{Name, Record},
+        tcp::TcpClientStream,
+        xfer::DnsResponse,
+    },
+};
+use tracing::debug;
+
+use crate::error::BlastDNSError;
+use crate::utils::parse_resolver;
+
+/// Result of a zone transfer operation.
+#[derive(Debug)]
+pub struct ZoneTransferResult {
+    /// The zone origin (e.g., "example.com.")
+    pub zone: String,
+    /// The nameserver that was queried
+    pub nameserver: SocketAddr,
+    /// All records returned by the zone transfer
+    pub records: Vec<Record>,
+}
+
+/// Perform an AXFR (full zone transfer) against a specific nameserver.
+///
+/// Zone transfers are TCP-based operations that download all records from a DNS zone.
+/// This bypasses the normal worker pool since it requires a dedicated TCP connection.
+///
+/// # Arguments
+/// * `nameserver` - The nameserver to query (IP:port string, e.g., "1.2.3.4:53")
+/// * `zone` - The zone name to transfer (e.g., "example.com")
+/// * `timeout` - Connection/query timeout
+pub async fn zone_transfer(
+    nameserver: &str,
+    zone: &str,
+    timeout: Duration,
+) -> Result<ZoneTransferResult, BlastDNSError> {
+    let addr = parse_resolver(nameserver)?;
+
+    let zone_fqdn = if zone.ends_with('.') {
+        zone.to_string()
+    } else {
+        format!("{zone}.")
+    };
+
+    let zone_name = Name::from_str(&zone_fqdn).map_err(|e| BlastDNSError::InvalidHostname {
+        name: zone.to_string(),
+        source: e,
+    })?;
+
+    debug!("Starting AXFR for zone {zone} from {addr}");
+
+    // Create a TCP connection to the nameserver
+    let provider = hickory_client::proto::runtime::TokioRuntimeProvider::new();
+    let (stream_future, sender) = TcpClientStream::new(addr, None, Some(timeout), provider);
+
+    // Create the client (awaits TCP connection internally)
+    let (mut client, bg) = Client::new(stream_future, sender, None)
+        .await
+        .map_err(|e| BlastDNSError::ResolverSetupFailed {
+            resolver: addr,
+            source: e,
+        })?;
+
+    // Spawn the background task
+    let bg_handle = tokio::spawn(bg);
+
+    // Perform the zone transfer (AXFR, no last_soa = full transfer)
+    let mut xfr_stream = client.zone_transfer(zone_name, None);
+
+    // Collect all records from the transfer
+    let mut all_records: Vec<Record> = Vec::new();
+    while let Some(result) = xfr_stream.next().await {
+        let response: DnsResponse = result.map_err(|e| BlastDNSError::ResolverRequestFailed {
+            resolver: addr,
+            source: e,
+        })?;
+        all_records.extend(response.answers().iter().cloned());
+    }
+
+    debug!(
+        "AXFR complete for zone {zone} from {addr}: {} records",
+        all_records.len()
+    );
+
+    // Clean up the background task
+    bg_handle.abort();
+
+    Ok(ZoneTransferResult {
+        zone: zone.to_string(),
+        nameserver: addr,
+        records: all_records,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hickory_client::proto::rr::RecordType;
+
+    #[tokio::test]
+    async fn test_invalid_nameserver() {
+        let result = zone_transfer("not-an-ip", "example.com", Duration::from_secs(5)).await;
+        assert!(result.is_err());
+    }
+
+    /// Integration test: AXFR against local BIND9 test server.
+    /// Requires: ./scripts/start-test-axfr.sh
+    /// Run with: cargo test -- --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn test_local_zone_transfer() {
+        let result = zone_transfer(
+            "127.0.0.1:5354",
+            "zonetransfer.test",
+            Duration::from_secs(5),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.records.len() > 10,
+            "Expected many records, got {}",
+            result.records.len()
+        );
+        assert_eq!(result.zone, "zonetransfer.test");
+
+        // Verify expected record types
+        let has_soa = result
+            .records
+            .iter()
+            .any(|r| r.record_type() == RecordType::SOA);
+        assert!(has_soa, "Expected SOA record in zone transfer");
+
+        let has_a = result
+            .records
+            .iter()
+            .any(|r| r.record_type() == RecordType::A);
+        assert!(has_a, "Expected A record in zone transfer");
+
+        let has_mx = result
+            .records
+            .iter()
+            .any(|r| r.record_type() == RecordType::MX);
+        assert!(has_mx, "Expected MX record in zone transfer");
+    }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "blastdns"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
### Summary
- Add `zone_transfer()` function for performing AXFR queries over TCP
- Enable hickory's `dnssec-ring` feature for first-class DNSSEC record parsing
- Add BIND9 Docker test infrastructure for AXFR integration tests

### Zone transfer
New `zone_transfer(nameserver, zone, timeout)` function available in both Rust and Python. Uses hickory's `Client::zone_transfer()` over a dedicated TCP connection — bypasses the normal UDP worker pool since AXFR is a fundamentally different protocol operation.

```python
from blastdns import zone_transfer

records = await zone_transfer("1.2.3.4:53", "example.com")
for name, rtype, rdata in records:
    print(f"{name} {rtype} {rdata}")
```

### DNSSEC record parsing
Enabled `dnssec-ring` feature on `hickory-client`. NSEC, NSEC3, RRSIG, DS, DNSKEY, and 5 other DNSSEC types are now parsed into structured data instead of opaque `Unknown` blobs. For example, NSEC now returns `{"DNSSEC": {"NSEC": {"next_domain_name": "...", "type_bit_maps": [...]}}}` instead of base64-encoded wire format.

### Test infrastructure
- BIND9 Docker container (`scripts/start-test-axfr.sh`) serving a test zone on port 5354
- Zone file includes every record type: SOA, NS, A, AAAA, MX, CNAME, TXT, SRV, PTR, NSEC
- Python integration tests verify every record type survives the round trip
- Rust integration test (`cargo test -- --ignored`)
- CI updated to start/stop the AXFR server in both Rust and Python test workflows
